### PR TITLE
feat: added nvchad initial custom configs

### DIFF
--- a/nvchad/custom/README.md
+++ b/nvchad/custom/README.md
@@ -1,0 +1,3 @@
+# Example_config
+
+This can be used as an example custom config for NvChad. Do check the https://github.com/NvChad/nvcommunity

--- a/nvchad/custom/chadrc.lua
+++ b/nvchad/custom/chadrc.lua
@@ -1,0 +1,20 @@
+---@type ChadrcConfig
+local M = {}
+
+-- Path to overriding theme and highlights files
+local highlights = require "custom.highlights"
+
+M.ui = {
+  theme = "nord",
+  theme_toggle = { "nord", "one_light" },
+
+  hl_override = highlights.override,
+  hl_add = highlights.add,
+}
+
+M.plugins = "custom.plugins"
+
+-- check core.mappings for table structure
+M.mappings = require "custom.mappings"
+
+return M

--- a/nvchad/custom/configs/lspconfig.lua
+++ b/nvchad/custom/configs/lspconfig.lua
@@ -1,0 +1,17 @@
+local on_attach = require("plugins.configs.lspconfig").on_attach
+local capabilities = require("plugins.configs.lspconfig").capabilities
+
+local lspconfig = require "lspconfig"
+
+-- if you just want default config for the servers then put them in a table
+local servers = { "html", "cssls", "tsserver", "clangd" }
+
+for _, lsp in ipairs(servers) do
+  lspconfig[lsp].setup {
+    on_attach = on_attach,
+    capabilities = capabilities,
+  }
+end
+
+-- 
+-- lspconfig.pyright.setup { blabla}

--- a/nvchad/custom/configs/null-ls.lua
+++ b/nvchad/custom/configs/null-ls.lua
@@ -1,0 +1,21 @@
+local null_ls = require "null-ls"
+
+local b = null_ls.builtins
+
+local sources = {
+
+  -- webdev stuff
+  b.formatting.deno_fmt, -- choosed deno for ts/js files cuz its very fast!
+  b.formatting.prettier.with { filetypes = { "html", "markdown", "css" } }, -- so prettier works only on these filetypes
+
+  -- Lua
+  b.formatting.stylua,
+
+  -- cpp
+  b.formatting.clang_format,
+}
+
+null_ls.setup {
+  debug = true,
+  sources = sources,
+}

--- a/nvchad/custom/configs/overrides.lua
+++ b/nvchad/custom/configs/overrides.lua
@@ -1,0 +1,59 @@
+local M = {}
+
+M.treesitter = {
+  ensure_installed = {
+    "vim",
+    "lua",
+    "html",
+    "css",
+    "javascript",
+    "typescript",
+    "tsx",
+    "c",
+    "markdown",
+    "markdown_inline",
+  },
+  indent = {
+    enable = true,
+    -- disable = {
+    --   "python"
+    -- },
+  },
+}
+
+M.mason = {
+  ensure_installed = {
+    -- lua stuff
+    "lua-language-server",
+    "stylua",
+
+    -- web dev stuff
+    "css-lsp",
+    "html-lsp",
+    "typescript-language-server",
+    "deno",
+    "prettier",
+
+    -- c/cpp stuff
+    "clangd",
+    "clang-format",
+  },
+}
+
+-- git support in nvimtree
+M.nvimtree = {
+  git = {
+    enable = true,
+  },
+
+  renderer = {
+    highlight_git = true,
+    icons = {
+      show = {
+        git = true,
+      },
+    },
+  },
+}
+
+return M

--- a/nvchad/custom/highlights.lua
+++ b/nvchad/custom/highlights.lua
@@ -1,0 +1,19 @@
+-- To find any highlight groups: "<cmd> Telescope highlights"
+-- Each highlight group can take a table with variables fg, bg, bold, italic, etc
+-- base30 variable names can also be used as colors
+
+local M = {}
+
+---@type Base46HLGroupsList
+M.override = {
+  Comment = {
+    italic = true,
+  },
+}
+
+---@type HLTable
+M.add = {
+  NvimTreeOpenedFolderName = { fg = "green", bold = true },
+}
+
+return M

--- a/nvchad/custom/init.lua
+++ b/nvchad/custom/init.lua
@@ -1,0 +1,7 @@
+-- local autocmd = vim.api.nvim_create_autocmd
+
+-- Auto resize panes when resizing nvim window
+-- autocmd("VimResized", {
+--   pattern = "*",
+--   command = "tabdo wincmd =",
+-- })

--- a/nvchad/custom/mappings.lua
+++ b/nvchad/custom/mappings.lua
@@ -1,0 +1,23 @@
+---@type MappingsTable
+local M = {}
+
+M.general = {
+  n = {
+    [";"] = { ":", "enter command mode", opts = { nowait = true } },
+  },
+  v = {
+    [">"] = { ">gv", "indent"},
+  },
+}
+
+-- more keybinds!
+M.hop = {
+  n = {
+    ["<space>jc"] = { "<cmd>HopChar1<CR>", "Hop to word"},
+    ["<space>jw"] = { "<cmd>HopWord<CR>", "Hop to word"},
+    ["<space>jl"] = { "<cmd>HopLine<CR>", "Hop to line"},
+    ["<space>jp"] = { "<cmd>HopPattern<CR>", "Hop to pattern"},
+  }
+}
+
+return M

--- a/nvchad/custom/plugins.lua
+++ b/nvchad/custom/plugins.lua
@@ -1,0 +1,74 @@
+local overrides = require("custom.configs.overrides")
+
+---@type NvPluginSpec[]
+local plugins = {
+
+  -- Override plugin definition options
+
+  {
+    "neovim/nvim-lspconfig",
+    dependencies = {
+      -- format & linting
+      {
+        "jose-elias-alvarez/null-ls.nvim",
+        config = function()
+          require "custom.configs.null-ls"
+        end,
+      },
+    },
+    config = function()
+      require "plugins.configs.lspconfig"
+      require "custom.configs.lspconfig"
+    end, -- Override to setup mason-lspconfig
+  },
+
+  -- override plugin configs
+  {
+    "williamboman/mason.nvim",
+    opts = overrides.mason
+  },
+
+  {
+    "nvim-treesitter/nvim-treesitter",
+    opts = overrides.treesitter,
+  },
+
+  {
+    "nvim-tree/nvim-tree.lua",
+    opts = overrides.nvimtree,
+  },
+
+  -- Install a plugin
+  {
+    "max397574/better-escape.nvim",
+    event = "InsertEnter",
+    config = function()
+      require("better_escape").setup()
+    end,
+  },
+
+  -- To make a plugin not be loaded
+  -- {
+  --   "NvChad/nvim-colorizer.lua",
+  --   enabled = false
+  -- },
+
+  -- All NvChad plugins are lazy-loaded by default
+  -- For a plugin to be loaded, you will need to set either `ft`, `cmd`, `keys`, `event`, or set `lazy = false`
+  -- If you want a plugin to load on startup, add `lazy = false` to a plugin spec, for example
+  -- {
+  --   "mg979/vim-visual-multi",
+  --   lazy = false,
+  -- }
+
+  {
+    "smoka7/hop.nvim",
+    tag = 'v2.5.0',
+    config = function()
+      require"hop".setup { keys = 'etovxqpdygfblzhckisuran' }
+    end,
+    lazy = false,
+  },
+}
+
+return plugins


### PR DESCRIPTION
Added initial NvChad custom configs.

## Notes

NvChad maintainers removed default telescope `fzf` native support so you might want to add it yourself when installing `nvim`.
```bash
 {
     "nvim-telescope/telescope.nvim",
-    dependencies = { "nvim-treesitter/nvim-treesitter" },
+    dependencies = { "nvim-treesitter/nvim-treesitter", { "nvim-telescope/telescope-fzf-native.nvim", build = "make" } },
```