### PR TITLE
fix: clean up issues across config files

### DIFF
--- a/.config/zsh/docker-aliases.zsh
+++ b/.config/zsh/docker-aliases.zsh
@@ -22,7 +22,6 @@ alias dversion="docker compose version"
 alias dreload="docker compose restart"
 alias dkill="docker compose kill"
 alias dstart="docker compose start"
-alias dstop="docker compose stop"
 
 dnuke() {
   if [[ -z $(docker ps -aq) ]]; then

--- a/.config/zsh/git-aliases.zsh
+++ b/.config/zsh/git-aliases.zsh
@@ -72,7 +72,7 @@ alias gdfp="git diff --cached --name-only \
   | xargs -r -o nvim"
 
 # git unstaged file pick with preview
-alias gdcap="git status --porcelain | egrep '^ [^ ]|^\?\?' | cut -c4- \
+alias gdcap="git status --porcelain | grep -E '^ [^ ]|^\?\?' | cut -c4- \
   | fzf -m --preview 'git diff --color=always -- {}' \
   | xargs -r nvim"
 

--- a/tmux.conf
+++ b/tmux.conf
@@ -6,7 +6,7 @@ unbind [
 unbind ]
 bind [ previous-window
 bind ] next-window
-bind \ copy-mode
+bind \\ copy-mode
 
 # set vim mode by default
 set -g mode-keys vi

--- a/zshrc
+++ b/zshrc
@@ -96,24 +96,9 @@ source $ZSH/oh-my-zsh.sh
 # users are encouraged to define aliases within the ZSH_CUSTOM folder.
 # For a full list of active aliases, run `alias`.
 #
-# Example aliases
-alias zshrc="nvim ~/.zshrc"
-alias nvim-init="nvim ~/.config/nvim/lua/plugins/init.lua"
-alias nvim-mappings="nvim ~/.config/nvim/lua/mappings.lua"
-alias view="nvim -R"
-alias z="zellij"
-alias zdf="z d -f"
-alias zl="z ls"
-alias zls="z ls"
-alias za="z a"
-alias zn="z -n default -s"
-alias zpwd="z -n default -s $(basename `pwd`)"
-alias znuke="z delete-all-sessions"
-
 # https://github.com/zellij-org/zellij/issues/1933#issuecomment-2274464004
 autoload -U +X compinit && compinit
 . <( zellij setup --generate-completion zsh | sed -Ee 's/^(_(zellij) ).*/compdef \1\2/' )
-# alias ohmyzsh="mate ~/.oh-my-zsh"
 
 if [ "$(uname -m)" = "arm64" ]; then
   export DOCKER_DEFAULT_PLATFORM=linux/arm64
@@ -139,17 +124,17 @@ alias nvim-init="nvim ~/.config/nvim/lua/plugins/init.lua"
 alias nvim-config="cd ~/.config/nvim && nvim init.lua"
 alias nvim-mappings="nvim ~/.config/nvim/lua/mappings.lua"
 alias view="nvim -R"
- alias zstart="zellij setup --generate-auto-start zsh"
+alias zstart="zellij setup --generate-auto-start zsh"
 alias z="zellij"
 alias zdf="z d -f"
 alias zl="z ls"
 alias zls="z ls"
 alias za="z a"
 alias zn="z -n default -s"
-alias zpwd="z -n default -s $(basename `pwd`)"
+alias zpwd="z -n default -s $(basename $(pwd))"
 alias znuke="z delete-all-sessions"
 alias zs="z -s"
-  
+
 function zlz() {
   local sessions
   sessions=$(zellij list-sessions 2>/dev/null)


### PR DESCRIPTION
- Remove duplicate alias block in zshrc (lines 100-111 were superseded by later block)
- Fix leading whitespace on zstart alias and trailing whitespace in zshrc
- Replace deprecated backtick syntax with $() in zpwd alias
- Remove duplicate dstop alias in docker-aliases.zsh
- Replace deprecated egrep with grep -E in git-aliases.zsh
- Escape backslash in tmux.conf bind for tmux 3.1+ compatibility

https://claude.ai/code/session_017F6vfhWRjYNaftP8WaaE86