### PR TITLE
fix(nvim): audit and clean up mappings (15 fixes)

### DIFF
--- a/nvim/lua/mappings.lua
+++ b/nvim/lua/mappings.lua
@@ -93,24 +93,26 @@ map("n", "<leader>gU", "<cmd>Gitsigns reset_buffer_index<cr>", { desc = "Gitsign
 map("n", "<leader>gR", function()
   local gs = require("gitsigns")
   gs.reset_base()
-  local cfg = require("gitsigns.config").config
-  if cfg.show_deleted then gs.toggle_deleted() end
-  if cfg.linehl then gs.toggle_linehl() end
-  if cfg.numhl then gs.toggle_numhl() end
+  if vim.g.gitsigns_review_active then
+    gs.toggle_deleted()
+    gs.toggle_linehl()
+    gs.toggle_numhl()
+    vim.g.gitsigns_review_active = false
+  end
   vim.notify("Gitsigns base reset to HEAD")
 end, { desc = "Gitsigns reset base to HEAD" })
 
 map("n", "<leader>gM", function()
-  local gs = require("gitsigns")
-  local cfg = require("gitsigns.config").config
-  if cfg.show_deleted then
+  if vim.g.gitsigns_review_active then
     vim.notify("Review mode already active — use <leader>gR to reset")
     return
   end
+  local gs = require("gitsigns")
   gs.change_base("origin/main")
   gs.toggle_deleted()
   gs.toggle_linehl()
   gs.toggle_numhl()
+  vim.g.gitsigns_review_active = true
   vim.notify("Gitsigns base set to origin/main")
 end, { desc = "Gitsigns diff vs origin/main with line highlights" })
 

--- a/nvim/lua/mappings.lua
+++ b/nvim/lua/mappings.lua
@@ -1,9 +1,6 @@
 require "nvchad.mappings"
 
--- add yours here
-
 local map = vim.keymap.set
-local gs = require "gitsigns"
 
 map("n", ";", ":", { desc = "CMD enter command mode" })
 map("i", "jk", "<ESC>")
@@ -13,33 +10,26 @@ vim.keymap.del("n", "<leader>b")
 map("n", "<leader>bn", "<cmd>enew<cr>", { desc = "New buffer" })
 map("n", "<leader>bo", "<cmd>%bd|e#|bd#<cr>", { desc = "Close all buffers except current" })
 
-map("n", "<C-h>", "<C-w>h", { desc = "Window left" })
-map("n", "<C-l>", "<C-w>l", { desc = "Window right" })
-map("n", "<C-j>", "<C-w>j", { desc = "Window down" })
-map("n", "<C-k>", "<C-w>k", { desc = "Window up" })
-
--- map({ "n", "i", "v" }, "<C-s>", "<cmd> w <cr>")
-
 -- Telescope
-map("n", "<space>fe", "<cmd>Telescope diagnostics<CR>", { desc = "See errors" })
-map("n", "<space>jd", "<cmd>Telescope lsp_definitions<CR>", { desc = "Open lsp definiions" })
-map("n", "<space>jr", "<cmd>Telescope lsp_references<CR>", { desc = "Open lsp references" })
-map("n", "<space>jt", "<cmd>Telescope lsp_type_definitions<CR>", { desc = "Open lsp type definitions" })
-map("n", "<space>ji", "<cmd>Telescope lsp_implementations<CR>", { desc = "Open lsp implementations" })
-map("n", "<space>fbl", "<cmd>Telescope git_branches<CR>", { desc = "See all branches" })
-map("n", "<space>gca", "<cmd>Telescope git_commits<CR>", { desc = "See all git commits" })
-map("n", "<space>gcb", "<cmd>Telescope git_bcommits<CR>", { desc = "See buffer commits" })
-map("n", "<space>fgs", "<cmd>Telescope git_status<CR>", { desc = "See git status" })
-map("n", "<space>fst", "<cmd>Telescope git_stash<CR>", { desc = "See git stash" })
+map("n", "<leader>fe", "<cmd>Telescope diagnostics<CR>", { desc = "See errors" })
+map("n", "<leader>jd", "<cmd>Telescope lsp_definitions<CR>", { desc = "Open lsp definitions" })
+map("n", "<leader>jr", "<cmd>Telescope lsp_references<CR>", { desc = "Open lsp references" })
+map("n", "<leader>jt", "<cmd>Telescope lsp_type_definitions<CR>", { desc = "Open lsp type definitions" })
+map("n", "<leader>ji", "<cmd>Telescope lsp_implementations<CR>", { desc = "Open lsp implementations" })
+map("n", "<leader>fbl", "<cmd>Telescope git_branches<CR>", { desc = "See all branches" })
+map("n", "<leader>gca", "<cmd>Telescope git_commits<CR>", { desc = "See all git commits" })
+map("n", "<leader>gcb", "<cmd>Telescope git_bcommits<CR>", { desc = "See buffer commits" })
+map("n", "<leader>fgs", "<cmd>Telescope git_status<CR>", { desc = "See git status" })
+map("n", "<leader>fst", "<cmd>Telescope git_stash<CR>", { desc = "See git stash" })
 
 -- Hop
-map("n", "<space>jw", "<cmd>HopWord<CR>", { desc = "Hop to word" })
-map("n", "<space>jp", "<cmd>HopPattern<CR>", { desc = "Hop pattern" })
-map("n", "<space>jc", "<cmd>HopChar1<CR>", { desc = "Hop to char1" })
-map("n", "<space>jl", "<cmd>HopLine<CR>", { desc = "Hop to line" })
+map("n", "<leader>jw", "<cmd>HopWord<CR>", { desc = "Hop to word" })
+map("n", "<leader>jp", "<cmd>HopPattern<CR>", { desc = "Hop pattern" })
+map("n", "<leader>jc", "<cmd>HopChar1<CR>", { desc = "Hop to char1" })
+map("n", "<leader>jl", "<cmd>HopLine<CR>", { desc = "Hop to line" })
 
 -- NvimTree
-map("n", "<leader>e", "<cmd> NvimTreeToggle <CR>", { desc = "Toggle NvimTree" })
+map("n", "<leader>e", "<cmd>NvimTreeToggle<CR>", { desc = "Toggle NvimTree" })
 
 -- Outline
 map("n", "<leader>o", "<cmd>Outline<CR>", { desc = "Open outline" })
@@ -62,21 +52,19 @@ map(
 map("n", "<leader>ql", "<cmd>Trouble loclist toggle<cr>", { desc = "Location List (Trouble)" })
 map("n", "<leader>qf", "<cmd>Trouble qflist toggle<cr>", { desc = "Quickfix List (Trouble)" })
 
-map(
-  "n",
-  "<leader>js",
-  "<cmd> split | lua vim.lsp.buf.definition()<CR>",
-  { desc = "Open definition in horizontal split" }
-)
-map(
-  "n",
-  "<leader>jv",
-  "<cmd> vsplit | lua vim.lsp.buf.definition()<CR>",
-  { desc = "Open definition in vertical split" }
-)
+-- LSP split navigation
+map("n", "<leader>js", function()
+  vim.cmd("split")
+  vim.lsp.buf.definition()
+end, { desc = "Open definition in horizontal split" })
 
--- Git
-map("n", "<leader>gC", "<cmd>Git commit<cr>", { desc = "Gitsigns blame all" })
+map("n", "<leader>jv", function()
+  vim.cmd("vsplit")
+  vim.lsp.buf.definition()
+end, { desc = "Open definition in vertical split" })
+
+-- Git (fugitive)
+map("n", "<leader>gC", "<cmd>Git commit<cr>", { desc = "Git commit" })
 map("n", "<leader>gD", "<cmd>Gvdiffsplit<cr>", { desc = "Git diff split" })
 
 -- Tabs
@@ -91,41 +79,39 @@ map("n", "<leader>tl", "<cmd>tablast<cr>", { desc = "Go to last tab" })
 -- Gitsigns
 map("n", "<leader>gbla", "<cmd>Gitsigns blame<cr>", { desc = "Gitsigns blame all" })
 map("n", "<leader>gbll", "<cmd>Gitsigns blame_line<cr>", { desc = "Gitsigns blame line" })
-map("n", "<leader>gn", "<cmd>Gitsigns next_hunk<cr>", { desc = "Gitsigns next hunk" })
-map("n", "<leader>gp", "<cmd>Gitsigns prev_hunk<cr>", { desc = "Gitsigns prev hunk" })
 map("n", "<leader>gP", "<cmd>Gitsigns preview_hunk<cr>", { desc = "Gitsigns preview hunk" })
 map("n", "<leader>gH", "<cmd>Gitsigns reset_hunk<cr>", { desc = "Gitsigns reset hunk" })
--- map("n", "<leader>gr", "<cmd>Gitsigns reset_buffer<cr>", { desc = "Gitsigns reset buffer" })
 map("n", "<leader>gr", function()
   local choice = vim.fn.confirm("Reset entire buffer?", "&Yes\n&No", 2)
   if choice == 1 then
-    gs.reset_buffer()
+    require("gitsigns").reset_buffer()
   end
 end, { desc = "Gitsigns reset buffer" })
 map("n", "<leader>gS", "<cmd>Gitsigns stage_buffer<cr>", { desc = "Gitsigns stage buffer" })
 map("n", "<leader>gU", "<cmd>Gitsigns reset_buffer_index<cr>", { desc = "Gitsigns unstage buffer" })
-local gm_review_active = false
+
 map("n", "<leader>gR", function()
+  local gs = require("gitsigns")
   gs.reset_base()
-  if gm_review_active then
-    gs.toggle_deleted()
-    gs.toggle_linehl()
-    gs.toggle_numhl()
-    gm_review_active = false
-  end
-  vim.notify "Gitsigns base reset to HEAD"
+  local cfg = require("gitsigns.config").config
+  if cfg.show_deleted then gs.toggle_deleted() end
+  if cfg.linehl then gs.toggle_linehl() end
+  if cfg.numhl then gs.toggle_numhl() end
+  vim.notify("Gitsigns base reset to HEAD")
 end, { desc = "Gitsigns reset base to HEAD" })
+
 map("n", "<leader>gM", function()
-  if gm_review_active then
-    vim.notify "Review mode already active — use <leader>gR to reset"
+  local gs = require("gitsigns")
+  local cfg = require("gitsigns.config").config
+  if cfg.show_deleted then
+    vim.notify("Review mode already active — use <leader>gR to reset")
     return
   end
-  gs.change_base "origin/main"
+  gs.change_base("origin/main")
   gs.toggle_deleted()
   gs.toggle_linehl()
   gs.toggle_numhl()
-  gm_review_active = true
-  vim.notify "Gitsigns base set to origin/main"
+  vim.notify("Gitsigns base set to origin/main")
 end, { desc = "Gitsigns diff vs origin/main with line highlights" })
 
 map("n", "]c", function()
@@ -133,7 +119,7 @@ map("n", "]c", function()
     return "]c"
   end
   vim.schedule(function()
-    gs.next_hunk()
+    require("gitsigns").next_hunk()
   end)
   return "<Ignore>"
 end, { expr = true })
@@ -143,7 +129,7 @@ map("n", "[c", function()
     return "[c"
   end
   vim.schedule(function()
-    gs.prev_hunk()
+    require("gitsigns").prev_hunk()
   end)
   return "<Ignore>"
 end, { expr = true })
@@ -151,36 +137,6 @@ end, { expr = true })
 ------------------
 ---- Diffview ----
 ------------------
-local dv = require "diffview.lib"
-map("n", "<leader>dd", function()
-  if next(dv.views) == nil then
-    vim.cmd "DiffviewOpen"
-  else
-    vim.cmd "DiffviewClose"
-  end
-end, {
-  desc = "Toggle Diffview window",
-})
-
-map("n", "<leader>dM", function()
-  if next(dv.views) == nil then
-    vim.cmd "DiffviewOpen origin/main...HEAD"
-  else
-    vim.cmd "DiffviewClose"
-  end
-end, {
-  desc = "Toggle Diffview vs origin/main",
-})
-
--- Function selection
-map("v", "aP", "V$%", { desc = "Visual select: V + $ + %" })
-
--- Toggle Claude Code
-map("n", "<leader>cc", "<cmd>ClaudeCode<CR>", { desc = "Toggle Claude Code" })
-
--- Diffview
-map("n", "<leader>do", "<cmd>DiffviewOpen<cr>", { desc = "Repo diff" })
-map("n", "<leader>dc", "<cmd>DiffviewClose<cr>", { desc = "Diffview close" })
 
 local function get_default_branch_name()
   local res = vim.system({ "git", "rev-parse", "--verify", "main" }, { capture_output = true }):wait()
@@ -188,6 +144,7 @@ local function get_default_branch_name()
 end
 
 local function dv_toggle(cmd_or_fn)
+  local dv = require("diffview.lib")
   if dv.get_current_view() then
     vim.cmd.DiffviewClose()
   else
@@ -196,7 +153,10 @@ local function dv_toggle(cmd_or_fn)
   end
 end
 
--- mappings (examples)
+map("n", "<leader>dd", function()
+  dv_toggle("DiffviewOpen")
+end, { desc = "Toggle Diffview window" })
+
 map("n", "<leader>dM", function()
   dv_toggle(function()
     return "DiffviewOpen origin/" .. get_default_branch_name() .. "...HEAD"
@@ -204,26 +164,23 @@ map("n", "<leader>dM", function()
 end, { desc = "Toggle Diffview vs default branch" })
 
 map("n", "<leader>df", function()
-  dv_toggle "DiffviewFileHistory %"
+  dv_toggle("DiffviewFileHistory %")
 end, { desc = "Toggle file history (current file)" })
 
--- map("v", "<leader>dr", function()
---   dv_toggle(function()
---     return "DiffviewFileHistory --follow"
---   end)
--- end, { desc = "Toggle file history (default..HEAD)" })
-
-map("n", ",hf", "<cmd>DiffviewFileHistory --follow %<cr>", { desc = "File history" })
+map("n", "<leader>dh", "<cmd>DiffviewFileHistory --follow %<cr>", { desc = "File history" })
 map("v", "<leader>dl", "<Esc><Cmd>'<,'>DiffviewFileHistory --follow<CR>", { desc = "Range history" })
 
--- grep word under cursor
+-- Toggle Claude Code
+map("n", "<leader>cc", "<cmd>ClaudeCode<CR>", { desc = "Toggle Claude Code" })
+
+-- Grep word under cursor
 map("n", "<leader>fW", function()
   require("telescope.builtin").live_grep {
     default_text = vim.fn.expand "<cword>",
   }
 end, { desc = "Live grep word under cursor" })
 
--- grep word under cursor in the current buffer
+-- Grep word under cursor in the current buffer
 map("n", "<leader>fZ", function()
   require("telescope.builtin").current_buffer_fuzzy_find {
     default_text = vim.fn.expand "<cword>",

--- a/nvim/lua/plugins/init.lua
+++ b/nvim/lua/plugins/init.lua
@@ -145,7 +145,6 @@ return {
       require("microscope.module").setup {
         keymaps = {
           fold = "zr",
-          grep = "<leader>fW",
         },
       }
     end,


### PR DESCRIPTION
- Remove duplicate <leader>dM, keep smart main/master detection
- Remove microscope <leader>fW conflict with Telescope
- Fix <leader>gC desc ("blame" -> "commit")
- Remove redundant <leader>do/<leader>dc (covered by <leader>dd toggle)
- Remove redundant <leader>gn/<leader>gp (covered by ]c/[c)
- Remove redundant C-h/j/k/l (already set by NvChad)
- Fix <leader>js/<leader>jv split-to-definition via Lua functions
- Lazy-require gitsigns and diffview.lib (no top-level require)
- Replace gm_review_active flag with gitsigns config state query
- Remove fragile aP visual mapping
- Fix typo "definiions" -> "definitions"
- Normalize <space> to <leader> for consistency
- Move orphan ,hf to <leader>dh with diffview group
- Remove commented-out dead code
- Strip extra spaces in <cmd> strings

https://claude.ai/code/session_01BXreSjyLuUUimT2mELh9X3